### PR TITLE
Allow tag() without block argument

### DIFF
--- a/lib/DSL/HTML.pm
+++ b/lib/DSL/HTML.pm
@@ -120,18 +120,20 @@ default_export tag dsl_html {
         $rendering->insert($tag);
     }
 
-    $rendering->push_tag($tag);
-    my @result;
-    my $success = eval {
-        @result = $block->($tag);
-        1;
-    };
-    my $error = $@;
-    $rendering->pop_tag($tag);
-    die $error unless $success;
+    if ( $block ) {
+        $rendering->push_tag($tag);
+        my @result;
+        my $success = eval {
+            @result = $block->($tag);
+            1;
+        };
+        my $error = $@;
+        $rendering->pop_tag($tag);
+        die $error unless $success;
 
-    $tag->push_content(@result)
-        if @result && !ref $result[0] && !$tag->content_list;
+        $tag->push_content(@result)
+            if @result && !ref $result[0] && !$tag->content_list;
+    }
 
     return;
 }

--- a/t/DSL-HTML.t
+++ b/t/DSL-HTML.t
@@ -17,12 +17,13 @@ my $WANT = <<EOT;
     </head>
     <body>
         <div>test</div>
-        <!--comment-->
+        <b>literal</b>
         <div>nested body</div>
         <div class="a c e" id="bar" style="display: none;">
         </div>
         <div foo="bar" id="go_away">
         </div>simple text<div>test</div>
+        <b>literal</b>
         <div>nested body</div>
         <div class="a c e" id="bar" style="display: none;">
         </div>
@@ -55,7 +56,7 @@ describe exports {
 
         tag div { 'test' }
 
-        tag('~comment', text => 'comment');
+        tag('~literal', text => '<b>literal</b>');
 
         css 'a.css';
         css 'b.css';

--- a/t/DSL-HTML.t
+++ b/t/DSL-HTML.t
@@ -17,6 +17,7 @@ my $WANT = <<EOT;
     </head>
     <body>
         <div>test</div>
+        <!--comment-->
         <div>nested body</div>
         <div class="a c e" id="bar" style="display: none;">
         </div>
@@ -53,6 +54,9 @@ describe exports {
         my $count = shift;
 
         tag div { 'test' }
+
+        tag('~comment', text => 'comment');
+
         css 'a.css';
         css 'b.css';
         css 'b.css'; # duplicate

--- a/t/simple.t
+++ b/t/simple.t
@@ -34,6 +34,8 @@ template simple {
         tag h2 { "inner!" }
         include foo => @inner;
     }
+
+    tag('~literal', text => '<b>literal text</b>');
 }
 
 my $html;


### PR DESCRIPTION
This allows things like:
```perl
  tag('~literal', text => '<b>Hello!</b>');
```